### PR TITLE
Remove cloud.gov ref

### DIFF
--- a/IAM/component.yaml
+++ b/IAM/component.yaml
@@ -8,128 +8,128 @@ satisfies:
 - control_key: AC-2 (5)
   covered_by: []
   implementation_status: none
-  narrative: 'Account log out is set to 15 minutes of inactivity within the IAM console
-    per account within the organization virtual infrastructure.
-
-    '
+  narrative: "Account log out is set to 15 minutes of inactivity within the Identity and Access Management (IAM) console
+    per account within the organization's virtual infrastructure.
+    "
   standard_key: NIST-800-53
 - control_key: AC-2 (1)
   covered_by: []
   implementation_status: none
-  narrative: 'AWS infrastructure as a service Management Life Cycle is automated to
-    use AWS CLI scripts. The organization AWS VPC can use the AWS Command Line
+  narrative: "AWS infrastructure as a service Management Life Cycle is automated to
+    use AWS CLI scripts. The organization's AWS Virtual Private Cloud (VPC) can use the AWS Command Line
     Interface (CLI) to automate the account management LifeCycle within its envoriment.
-    The organization uses the AWS IAM console for semi-automated automated account manamgemt
-
-    '
+    The organization uses the AWS Identity and Access Management (IAM) console for semi-automated 
+    automated account manamgemt.
+    "
   standard_key: NIST-800-53
 - control_key: AC-6
   covered_by: []
   implementation_status: none
-  narrative: 'IAM policies are attached to the users, enabling centralized control
-    of permissions for users under the ogranizations AWS Account to access services, buckets or
-    objects. With IAM policies, the ogranizations only grant users within its own AWS account permission
-    to access its Amazon resources.
+  narrative: "Identity and Access Management (IAM) policies are attached to the users, enabling centralized control
+    of permissions for users under the organization's AWS Account to access services, buckets or
+    objects. With IAM policies, the organization only grant users 
+    within its own AWS account permission to access its Amazon resources.
 
-    AWS IAM policies are defined to grant only the required access for the ogranization staff
-    necessary to perform their functions. The organizatioT defines least privilege access to each
+    AWS IAM policies are defined to grant only the required access for the organizational staff
+    necessary to perform their functions. The organization defines least privilege access to each
     user, group or role.
 
     Security functions within the AWS infrastructure are explicitly defined within
     IAM to include read-only permissions for any user functions.
 
-    The organization incorporate running the IAM Policy Simulator to test policies for least privilege
+    The organization incorporates running the IAM Policy Simulator to test policies for least privilege
     access for users and groups.
-
-    '
+    "
   standard_key: NIST-800-53
 - control_key: AC-6 (1)
   covered_by: []
   implementation_status: none
-  narrative: 'The organization explicitly authorizes access to administrative and security functions
+  narrative: "The organization explicitly authorizes access to administrative and security functions
     of its virtual infrastructure and residing platforms to designated individuals
-    within the organizations SecOps and DevOps team.  No other authorizations to security and administrative
+    within the organization's SecOps and DevOps team.  No other authorizations to security and administrative
     information is granted to individuals outside these teams.
-
-    '
+    "
   standard_key: NIST-800-53
 - control_key: AC-2 (2)
   covered_by: []
   implementation_status: none
-  narrative: 'This control is not applicable. All Temporary accounts are handled by
-    associating resources with IAM Roles. There are no guest/anonymous, group, or
-    temporary user accounts in the organization AWS environment.
-
-    '
+  narrative: "This control is not applicable. All Temporary accounts are handled by
+    associating resources with Identity and Access Management (IAM) Roles. There are no guest/anonymous, group, or
+    temporary user accounts in the organization's AWS environment.
+    "
   standard_key: NIST-800-53
 - control_key: AC-5
   covered_by: []
   implementation_status: none
-  narrative: "#### a  \nThe organization implements IAM Policies\
+  narrative: "#### a  \nThe organization implements Identity and Access Management (IAM) Policies\
     \ roles and  individual user accounts for separation of duties.  IAM policies\
     \ are attached to the users, enabling centralized control of permissions for users\
-    \ under  AWS Account.\n  \n#### b  \nThe ogranization documents separation of duties of\
+    \ under  AWS Account.\n  \n#### b  \nThe organization documents separation of duties of\
     \ AWS users. All AWS IAM users, groups and roles can be viewed\
     \ wthin the AWS console. IAM users reports are generated to show all separation\
-    \ of duties. \n"
+    \ of duties. \n
+    "
   standard_key: NIST-800-53
 - control_key: AC-14
   covered_by: []
   implementation_status: none
   narrative: "#### a  \nThere are no administrative actions than can be performed\
-    \ within the organization VPC without multifactor authentication.  Per AWS,\
+    \ within the organization's Virtual Private Cloud (VPC) without multifactor authentication.  Per AWS,\
     \ privileged users can not gain access to the AWS console without identification and authorization\
-    \ to its a vpc.\n  \n#### b  \nIt is not possible for members of the 18F Devops\
-    \ and SecOps teams to aceess the ogranization VPC infrastructure without\
-    \ muitifactor authetication. \n  \n"
+    \ to its a VPC.\n  \n#### b  \nIt is not possible for members of the 18F Devops\
+    \ and SecOps teams to aceess the organization's VPC infrastructure without\
+    \ muitifactor authetication. \n  \n
+    "
   standard_key: NIST-800-53
 - control_key: AC-3
   covered_by: []
   implementation_status: none
-  narrative: "The ogranization follows best practices by implementing the majority of the following:\n\
-    \  - Create the ogranization individual accounts for anyone that requires access to the virtual\
-    \ infrastructure or APIs or use IAM federation from enterprise identity management\
-    \ system\n  - Use groups or roles to assign permissions to IAM users and Cloud.gov\n\
+  narrative: "The organization follows best practices by implementing the majority of the following:\n\
+    \  - Create the organization's individual accounts for anyone that requires access to the virtual\
+    \ infrastructure or APIs or use Identity and Access Management (IAM) federation from enterprise identity management\
+    \ system\n  - Use groups or roles to assign permissions to IAM users\n\
     \  - Enable multi factor authentication for all IAM users\n  - Use roles for applications\
     \ that run on EC2 instances\n  - Delegate by using roles instead of sharing credentials\n\
     \  - Rotate credentials regularly\n  - Store SSH keys securely to prevent disclosure,\
-    \ and promptly replace lost or compromised keys.\n"
+    \ and promptly replace lost or compromised keys.\n
+    "
   standard_key: NIST-800-53
 - control_key: AC-2
   covered_by: []
   implementation_status: none
   narrative: "#### a  \nAWS accounts are managed through AWS Identity and Access Management\
     \ (IAM). Only users with a need to operate the AWS management console are provided\
-    \ individual AWS user accounts. The following types are used:\n  * User \u2013\
-    \ Individual IAM accounts\n  * System \u2013 system and application account not\
+    \ individual AWS user accounts. The following types are used:\n  * User-\
+    \ Individual IAM accounts\n  * System- system and application account not\
     \ used for interactive access\nThere are no guest/anonymous, groups, or temporary\
-    \ user accounts in the organization environment\n  \n#### k  \nThe organization does not allow shared/group\
+    \ user accounts in the organization's environment\n  \n#### k  \nThe organization does not allow shared/group\
     \ account credentials within the AWS environment. All users have individual accounts\
     \ to access the AWS environment. The organization has created specific policies that allow\
-    \ individual users to assume a role within the AWS environment.\n  \n"
+    \ individual users to assume a role within the AWS environment.\n  \n
+    "
   standard_key: NIST-800-53
 - control_key: AC-6 (5)
   covered_by: []
   implementation_status: none
-  narrative: "The ogranization restricts privileged accounts such as administrator and root access\
+  narrative: "The organization restricts privileged accounts such as administrator and root access\
     \ accounts to designated members within the Devops and SecOps teams. Within\
     \ the virtual infrastructure the admin account is not used for privileged access.\
-    \ It\u2019s only used for billing and metrics.\n"
+    \ It\u2019s only used for billing and metrics.\n
+    "
   standard_key: NIST-800-53
 - control_key: IA-2
   covered_by: []
   implementation_status: none
-  narrative: 'All users have individually unique identifiers to access and authenticate
-    to the AWS environment through the AWS management console. The organization AWS IAM users are
-    placed into IAM roles based on their assigned roles and permissions
+  narrative: "All users have individually unique identifiers to access and authenticate
+    to the AWS environment through the AWS management console. The organization's AWS Identity and 
+    Access Management (IAM) users are placed into IAM roles based on their assigned roles and permissions
 
     Additional temporary permission are delegated with the IAM roles usually for applications
-    that run on EC2 Instances in order to access AWS resources All user accounts for
-    18F staff are maintained within the organization AWS Environment.
+    that run on EC2 Instances in order to access AWS resources all user accounts for
+    staff are maintained within the organization's AWS environment.
 
     Shared or group authenticators are not utilized, Service accounts are implemented
     as Managed Services Accounts within AWS.
-
-    '
+    "
   standard_key: NIST-800-53
 schema_version: 2.0

--- a/IAM/component.yaml
+++ b/IAM/component.yaml
@@ -9,7 +9,7 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: 'Account log out is set to 15 minutes of inactivity within the IAM console
-    per accountwithin the 18F virtual infrastructure.
+    per account within the organization virtual infrastructure.
 
     '
   standard_key: NIST-800-53
@@ -17,9 +17,9 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: 'AWS infrastructure as a service Management Life Cycle is automated to
-    use AWS CLI scripts. 18F AWS Virtual Private Cloud can use the AWS Command Line
+    use AWS CLI scripts. The organization AWS VPC can use the AWS Command Line
     Interface (CLI) to automate the account management LifeCycle within its envoriment.
-    18F uses the AWS IAM console for semi-automated automated account manamgemt
+    The organization uses the AWS IAM console for semi-automated automated account manamgemt
 
     '
   standard_key: NIST-800-53
@@ -27,18 +27,18 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: 'IAM policies are attached to the users, enabling centralized control
-    of permissions for users under 18F AWS Account to access services, buckets or
-    objects. With IAM policies, 18F only grant users within its own AWS account permission
+    of permissions for users under the ogranizations AWS Account to access services, buckets or
+    objects. With IAM policies, the ogranizations only grant users within its own AWS account permission
     to access its Amazon resources.
 
-    18F AWS IAM policies are defined to grant only the required access for 18F staff
-    necessary to perform their functions. 18F defines least privilege access to each
+    AWS IAM policies are defined to grant only the required access for the ogranization staff
+    necessary to perform their functions. The organizatioT defines least privilege access to each
     user, group or role.
 
     Security functions within the AWS infrastructure are explicitly defined within
     IAM to include read-only permissions for any user functions.
 
-    18F incorporate running the IAM Policy Simulator to test policies for least privilege
+    The organization incorporate running the IAM Policy Simulator to test policies for least privilege
     access for users and groups.
 
     '
@@ -46,9 +46,9 @@ satisfies:
 - control_key: AC-6 (1)
   covered_by: []
   implementation_status: none
-  narrative: '18F explicitly authorizes access to administrative and security functions
-    of its virtual infrastructure and Cloud.Gov platform to designated individuals
-    within the Devops and SecOps team.  No other authrozations to security and administrative
+  narrative: 'The organization explicitly authorizes access to administrative and security functions
+    of its virtual infrastructure and residing platforms to designated individuals
+    within the organizations SecOps and DevOps team.  No other authorizations to security and administrative
     information is granted to individuals outside these teams.
 
     '
@@ -58,39 +58,36 @@ satisfies:
   implementation_status: none
   narrative: 'This control is not applicable. All Temporary accounts are handled by
     associating resources with IAM Roles. There are no guest/anonymous, group, or
-    temporary user accounts in the 18F AWS environment.
+    temporary user accounts in the organization AWS environment.
 
     '
   standard_key: NIST-800-53
 - control_key: AC-5
   covered_by: []
   implementation_status: none
-  narrative: "#### a  \n18F  implements Identity and Access Management (IAM) Policies\
+  narrative: "#### a  \nThe organization implements IAM Policies\
     \ roles and  individual user accounts for separation of duties.  IAM policies\
     \ are attached to the users, enabling centralized control of permissions for users\
-    \ under 18Fs AWS Account.\n  \n#### b  \n18F documents separation of duties of\
-    \ AWS and Cloud Foundry users. All AWS IAM users, groups and roles can be viewed\
+    \ under  AWS Account.\n  \n#### b  \nThe ogranization documents separation of duties of\
+    \ AWS users. All AWS IAM users, groups and roles can be viewed\
     \ wthin the AWS console. IAM users reports are generated to show all separation\
-    \ of duties. Cloud Checkr also generates an a report of all IAM users within 18F\
-    \ AWS environment.\n  \n"
+    \ of duties. \n"
   standard_key: NIST-800-53
 - control_key: AC-14
   covered_by: []
   implementation_status: none
-  narrative: "#### a  \nThere are no user or administrative actions than can be performed\
-    \ within 18F virtual private cloud without multifactor authentication.  Per AWS,\
-    \ users can not gain access to the AWS console without identification and authorization\
+  narrative: "#### a  \nThere are no administrative actions than can be performed\
+    \ within the organization VPC without multifactor authentication.  Per AWS,\
+    \ privileged users can not gain access to the AWS console without identification and authorization\
     \ to its a vpc.\n  \n#### b  \nIt is not possible for members of the 18F Devops\
-    \ and SecOps teams to aceess the 18F virtual private cloud infrastructure without\
-    \ muitifactor authetication and identification. All clinet users of Cloud.gov\
-    \ must login using authenticated credentials in order to access the system as\
-    \ stated in Part A above.\n  \n"
+    \ and SecOps teams to aceess the ogranization VPC infrastructure without\
+    \ muitifactor authetication. \n  \n"
   standard_key: NIST-800-53
 - control_key: AC-3
   covered_by: []
   implementation_status: none
-  narrative: "18F follows best practices by implementing the majority of the following:\n\
-    \  - Create individual accounts for anyone that requires access to the virtual\
+  narrative: "The ogranization follows best practices by implementing the majority of the following:\n\
+    \  - Create the ogranization individual accounts for anyone that requires access to the virtual\
     \ infrastructure or APIs or use IAM federation from enterprise identity management\
     \ system\n  - Use groups or roles to assign permissions to IAM users and Cloud.gov\n\
     \  - Enable multi factor authentication for all IAM users\n  - Use roles for applications\
@@ -106,16 +103,16 @@ satisfies:
     \ individual AWS user accounts. The following types are used:\n  * User \u2013\
     \ Individual IAM accounts\n  * System \u2013 system and application account not\
     \ used for interactive access\nThere are no guest/anonymous, groups, or temporary\
-    \ user accounts in the 18F Environment\n  \n#### k  \n18F does not allow shared/group\
+    \ user accounts in the organization environment\n  \n#### k  \nThe organization does not allow shared/group\
     \ account credentials within the AWS environment. All users have individual accounts\
-    \ to access the AWS environment. 18F has created specific policies that allow\
+    \ to access the AWS environment. The organization has created specific policies that allow\
     \ individual users to assume a role within the AWS environment.\n  \n"
   standard_key: NIST-800-53
 - control_key: AC-6 (5)
   covered_by: []
   implementation_status: none
-  narrative: "18F restricts privileged accounts such as administrator and root access\
-    \ accounts to designated members within the18F Devops and SecOps teams. Within\
+  narrative: "The ogranization restricts privileged accounts such as administrator and root access\
+    \ accounts to designated members within the Devops and SecOps teams. Within\
     \ the virtual infrastructure the admin account is not used for privileged access.\
     \ It\u2019s only used for billing and metrics.\n"
   standard_key: NIST-800-53
@@ -123,12 +120,12 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: 'All users have individually unique identifiers to access and authenticate
-    to the AWS environment through the AWS management console. 18F AWS IAM users are
+    to the AWS environment through the AWS management console. The organization AWS IAM users are
     placed into IAM roles based on their assigned roles and permissions
 
     Additional temporary permission are delegated with the IAM roles usually for applications
     that run on EC2 Instances in order to access AWS resources All user accounts for
-    18F staff are maintained within the 18F AWS Environment.
+    18F staff are maintained within the organization AWS Environment.
 
     Shared or group authenticators are not utilized, Service accounts are implemented
     as Managed Services Accounts within AWS.

--- a/VPC/component.yaml
+++ b/VPC/component.yaml
@@ -41,9 +41,9 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: "Since the infromation system platform resides within the defined virtual infrastructure,\
-    \ PU must use SSH remote access method to troubleshoot issues and\
-    \ update services that are only resolved by logging into a bastion host (BH).\
-    \ The BH themselves are virtual machine deployed within the organization\u2019s\
+    \ Privileged User (PU) must use SSH remote access method to troubleshoot issues and\
+    \ update services that are only resolved by logging into a Bastion Host (BH).\
+    \ The BH themselves are virtual machine deployed within the organization's\
     \ virtual private cloud. They are the only access points for designated PU\
     \ members to run privileged commnds that affect the entire platform. No other\
     \ privileged remote access is available to the information system.\n"
@@ -51,13 +51,13 @@ satisfies:
 - control_key: AC-4
   covered_by: []
   implementation_status: none
-  narrative: "Organization incorporates security features within its vpc such as IAM security\
+  narrative: "The organization incorporates security features within its vpc such as IAM security\
     \ groups, network ACLs, routing tables, and external gateways. Each of these items\
     \ is complementary to providing a secure, isolated network.\nNetwork Access control\
     \ lists (ACLs) are created to allow or deny traffic entering or exiting these\
     \ subnets. Each subnet has routing tables attached to them to direct the flow\
     \ of network traffic to Internet gateways, virtual private gateways, Network Address\
-    \ Translation (NAT) for private subnets.\nThe organization\u2019s VPC infrastructure\
+    \ Translation (NAT) for private subnets.\nThe organization's Virtual Private Cloud (VPC) infrastructure\
     \ has firewalls enabling filtering on both ingress and egress traffic from its\
     \ instances. The default group enables inbound communication from other members\
     \ of the same group and outbound communication to any destination.\nTraffic is\

--- a/VPC/component.yaml
+++ b/VPC/component.yaml
@@ -8,9 +8,8 @@ satisfies:
 - control_key: AC-4 (21)
   covered_by: []
   implementation_status: none
-  narrative: 'The virtual private cloud logically separates the Cloud.Gov PaaS from
-    other information systens within its environment. Cloud.gov is hosted within its
-    own VPC and has its own dedicated elastic load balancers for incoming traffic.
+  narrative: 'The virtual private cloud logically separates the hosted services from other information systems within its environment. Any service built using AWS VPC will reside within its
+    own virtual private network and may have its own dedicated elastic load balancers for incoming traffic.
 
     '
   standard_key: NIST-800-53
@@ -24,41 +23,41 @@ satisfies:
     \ boundary devices employ rule sets, access control lists (ACL), and configurations\
     \ to enforce the flow of information to specific information system services.\n\
     ACLs, or traffic flow policies, are established on each managed interface, which\
-    \ manage and enforce the flow of traffic.\n18F connects to an AWS access point\
-    \ via HTTP or HTTPS using Secure Sockets Layer (SSL), a cryptographic protocol\
+    \ manage and enforce the flow of traffic.\n Designated privileged users(PU) connects to\
+    \ an AWS access point via HTTP or HTTPS using Secure Sockets Layer (SSL), a cryptographic protocol\
     \ that is designed to protect against eavesdropping, tampering, and message forgery.\n\
-    18F utilizes the AWS Virtual Private Cloud (VPC), which provides a private subnet\
+    PU utilizes the AWS Virtual Private Cloud (VPC), which provides a private subnet\
     \ within the AWS cloud. Each VPC is configured to utilize Routing Rules, Subnet\
     \ Rules, and Security Group Rules.  Each of these controls must have appropriate\
     \ rules and routes in-place before any external service is able to reach a host\
     \ within AWS.\n  \n#### b  \nEach VPC is configured to utilize Routing Tables,\
     \ and Security Groups.  Each of these controls must have appropriate rules and\
-    \ routes in-place before any external service is able to reach a host within Cloud\
-    \ Foundry.\n  \n#### c  \nThe Cloud.gov system is internal to the 18F Virtual\
-    \ Private Cloud (VPC) and does not connect to external networks or information\
-    \ systems outside the 18F Virtual Private Cloud (VPC).\n  \n"
+    \ routes in-place before any external service is able to reach the host within the \
+    \ information system boundry.\n  \n#### c  \nThe information system is internal to the defined\
+    \ VPC and does not connect to external networks or information\
+    \ systems outside the VPC.\n  \n"
   standard_key: NIST-800-53
 - control_key: AC-17 (4)
   covered_by: []
   implementation_status: none
-  narrative: "Since the Cloud.Gov platform resides within the 18F virtual infrastructure,\
-    \ 18F Devops must use the SSH remote access method to troubleshoot issues and\
-    \ update services that are only resolved by logging into the Cloud.Gov jumpboxes.\
-    \ The jumpboxes themselves are virtual machine deployed within the 18F\u2019s\
-    \ virtual private cloud. They are the only access points for designated Devops\
+  narrative: "Since the infromation system platform resides within the defined virtual infrastructure,\
+    \ PU must use SSH remote access method to troubleshoot issues and\
+    \ update services that are only resolved by logging into a bastion host (BH).\
+    \ The BH themselves are virtual machine deployed within the organization\u2019s\
+    \ virtual private cloud. They are the only access points for designated PU\
     \ members to run privileged commnds that affect the entire platform. No other\
     \ privileged remote access is available to the information system.\n"
   standard_key: NIST-800-53
 - control_key: AC-4
   covered_by: []
   implementation_status: none
-  narrative: "18F incorporates security features within its vpc such as IAM security\
+  narrative: "Organization incorporates security features within its vpc such as IAM security\
     \ groups, network ACLs, routing tables, and external gateways. Each of these items\
     \ is complementary to providing a secure, isolated network.\nNetwork Access control\
     \ lists (ACLs) are created to allow or deny traffic entering or exiting these\
     \ subnets. Each subnet has routing tables attached to them to direct the flow\
     \ of network traffic to Internet gateways, virtual private gateways, Network Address\
-    \ Translation (NAT) for private subnets.\n18F\u2019s virtual private cloud infrastructure\
+    \ Translation (NAT) for private subnets.\nThe organization\u2019s VPC infrastructure\
     \ has firewalls enabling filtering on both ingress and egress traffic from its\
     \ instances. The default group enables inbound communication from other members\
     \ of the same group and outbound communication to any destination.\nTraffic is\


### PR DESCRIPTION
I wanted to make this a more abstract component content so I can reuse it for other SSPs and possibly added more components to it.  The specific usage of this content should be spoken to on the consumer of the AWS service layer.  If I'm off basis let me know :)

related to issue #2 

@geramirez @jcscottiii @afeld 
