### PR TITLE
Fix typo, eliminate 18F references

### DIFF
--- a/CloudFormation/component.yaml
+++ b/CloudFormation/component.yaml
@@ -9,12 +9,12 @@ satisfies:
   covered_by: []
   implementation_status: none
   narrative: 'DevOps maintain baseline configurations for VPC, EBS, EC2 instances
-    and AMIs. AWS Cloud Formation templates help 18F maintain a strict configuration
-    management scheme of the cloud infrastructure. If an error or misconfiguration
-    of the infrastructure or associated security mechanism (security groups, NACLs)
-    is detected, the administrators can analyze the current infrastructure templates;
-    compare with previous versions, and redeploy the configurations to a known and
-    approved state.
+    and AMIs. AWS Cloud Formation templates help the organization maintain a strict 
+    configuration management scheme of the cloud infrastructure. If an error or
+    misconfiguration of the infrastructure or associated security mechanism (security
+    groups, NACLs) is detected, the administrators can analyze the current
+    infrastructure templates;compare with previous versions, and redeploy the
+    configurations to a known and approved state.
 
     AWS Cloud Formation templates are the approved baseline for all changes to the
     infrastructure and simplify provisioning and management on AWS. They provide an
@@ -33,16 +33,17 @@ satisfies:
 - control_key: CM-3
   covered_by: []
   implementation_status: none
-  narrative: '- 18F provisions its infrastructure with AWS CloudFormation, the AWS
-    CloudFormation template describes exactly what resources are provisioned and their
-    settings. Because these templates are text files, 18F can simply track differences
-    in these templates to track changes to its infrastructure, similar to the way
-    developers control revisions to source code.
+  narrative: '- The organization provisions its infrastructure with AWS
+    CloudFormation, the AWS CloudFormation template describes exactly what resources
+    are provisioned and their settings. Because these templates are text files, the
+    organization can simply track differences in these templates to track changes to
+    its infrastructure, similar to the way developers control revisions to source
+    code.
 
-    - 18F uses several version control systems(i.e. AWS Config, AWS Service Catalog)
-    with its templates to know exactly what changes were made, who made them, and
-    when. If at any point 18F needs to reverse changes to infrastructure, you can
-    use a previous version of a template.
+    - The organization uses several version control systems(i.e. AWS Config, AWS
+    Service Catalog) with its templates to know exactly what changes were made, who
+    made them, and when. If at any point the organization needs to reverse changes to
+    infrastructure, it can use a previous version of a template.
 
     '
   standard_key: NIST-800-53

--- a/IAM/component.yaml
+++ b/IAM/component.yaml
@@ -77,7 +77,7 @@ satisfies:
     \ within the organization's Virtual Private Cloud (VPC) without multifactor authentication.  Per AWS,\
     \ privileged users can not gain access to the AWS console without identification and authorization\
     \ to its a VPC.\n  \n#### b  \nIt is not possible for members of the 18F Devops\
-    \ and SecOps teams to aceess the organization's VPC infrastructure without\
+    \ and SecOps teams to access the organization's VPC infrastructure without\
     \ muitifactor authetication. \n  \n
     "
   standard_key: NIST-800-53


### PR DESCRIPTION
`s/aceess/access`, and replace mentions of 18F with mentions of "the organization."